### PR TITLE
update setcap README

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,13 +69,16 @@ You can also navigate to the releases page [here](https://github.com/solo-io/bum
 ### A note on permissions
 
 Loading eBPF programs to the kernel (`bee run` command) requires elevated privileges. 
-You can either run `bee` as root (with sudo), or add capabilities to the binary. To add capabilities, run the following command:
+You can either run `bee` as root (with sudo), or add capabilities to the binary.
+Adding capabilities is the preferred method, as if you run `bee run` with `sudo`, it will not find local images when you run `bee build` without sudo.
+
+To add capabilities, run the following command:
 
 ```bash
-sudo setcap cap_sys_resource,cap_sys_admin,cap_bpf+eip $(which bee)
+sudo setcap cap_sys_resource,cap_sys_admin+eip $(which bee)
 ```
 
-Adding capabilities is the preferred method, as if you run `bee run` with `sudo`, it will not find local images when you run `bee build` without sudo.
+On newer kernels you may be able to pare down the capabilities added, for example a recent addition is the `CAP_BPF` capability.
 
 ### Uninstall
 


### PR DESCRIPTION
`CAP_BPF` is a relatively recent capability and when it is missing attempting to add it will result in the `Invalid argument` error. To prevent getting started issues, going to opt for documenting more permissive caps but call out that this can be more specific.

fixes #61 