### PR TITLE
Add exitsnoop as an example

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -49,6 +49,8 @@ docker-push: docker-build
 activeconn: $(EXAMPLES_DIR)/activeconn
 .PHONY: tcpconnect
 tcpconnect: $(EXAMPLES_DIR)/tcpconnect
+.PHONY: exitsnoop
+tcpconnect: $(EXAMPLES_DIR)/exitsnoop
 
 
 $(EXAMPLES_DIR)/%:
@@ -56,7 +58,7 @@ $(EXAMPLES_DIR)/%:
 	$(OUTDIR)/bee-linux-amd64 push $(HUB)/$(REPO_NAME)/$*:$(VERSION)
 
 .PHONY: release-examples
-release-examples: activeconn tcpconnect
+release-examples: activeconn tcpconnect exitsnoop
 
 #----------------------------------------------------------------------------------
 # CLI

--- a/examples/exitsnoop/README.md
+++ b/examples/exitsnoop/README.md
@@ -1,0 +1,61 @@
+# Overview
+
+The exitsnoop example is heavily based on the [exitsnoop program in BCC's libbpf-tools](https://github.com/iovisor/bcc/blob/master/libbpf-tools/exitsnoop.bpf.c), which is itself based on the original [BCC exitsnoop](https://github.com/iovisor/bcc/blob/master/tools/exitsnoop.py).
+
+This eBPF program will trace all process termination (exit, fatal signals).
+
+# Usage
+
+To see all the syscalls in your environment, you can run your image without filters:
+
+```console
+bee run ghcr.io/solo-io/bumblebee/exitsnoop:$(bee version)
+```
+
+You can also try out the filtering capability by referencing fields in your BPF map:
+
+```c
+struct event {
+        __u64 start_time;
+        __u64 exit_time;
+        __u32 pid;
+        __u32 tid;
+        __u32 ppid;
+        __u32 sig;
+        int exit_code;
+        char comm[TASK_COMM_LEN];
+};
+```
+
+For example, to filter for all the syscalls where the `comm` is `bash`, you can use: 
+
+```console
+bee run -f="exits,comm,bash" ghcr.io/solo-io/bumblebee/exitsnoop:$(bee version)
+```
+
+# Prometheus integration
+
+Let's say, you want to visualize the rate of such syscalls in your Prometheus stack, or want to alert on certain syscalls.
+
+You can modify your `exit` map to generate a `counter` from your exit() calls:
+
+```c
+struct {
+        __uint(type, BPF_MAP_TYPE_RINGBUF);
+        __uint(max_entries, 1 << 24);
+        __type(value, struct event);
+} exits SEC(".maps.counter");
+```
+
+This will generate Prometheus metrics like this:
+
+```console
+# HELP ebpf_solo_io_exits 
+# TYPE ebpf_solo_io_exits counter
+ebpf_solo_io_exits{comm="infocmp",exit_code="0",exit_time="2396600383928",pid="16234",ppid="16221",sig="0",start_time="2396599269958",tid="16234"} 1
+ebpf_solo_io_exits{comm="ip6tables",exit_code="0",exit_time="2402597588547",pid="16237",ppid="2115",sig="0",start_time="2402596148575",tid="16237"} 1
+ebpf_solo_io_exits{comm="iptables",exit_code="0",exit_time="2397474999464",pid="16235",ppid="2115",sig="0",start_time="2397473028592",tid="16235"} 1
+```
+
+Note that some of the fields are not important in this usecase, and these can also overload your Prometheus instace, so if your use-case is only about Prometheus, you should consider removing these high cardinality fields from your map.
+`exit_time`, `start_time`, are fields that should be removed in this case.

--- a/examples/exitsnoop/exitsnoop.c
+++ b/examples/exitsnoop/exitsnoop.c
@@ -1,0 +1,64 @@
+/* SPDX-License-Identifier: (LGPL-2.1 OR BSD-2-Clause) */
+/* Copyright (c) 2021 Hengqi Chen */
+/* Adapted for `bee` from: https://github.com/iovisor/bcc/blob/master/libbpf-tools/exitsnoop.bpf.c */
+#include <vmlinux.h>
+#include <bpf/bpf_helpers.h>
+#include <bpf/bpf_core_read.h>
+#include "exitsnoop.h"
+
+const volatile pid_t target_pid = 0;
+const volatile bool trace_failed_only = false;
+const volatile bool trace_by_process = true;
+
+struct {
+        __uint(type, BPF_MAP_TYPE_RINGBUF);
+        __uint(max_entries, 1 << 24);
+        __type(value, struct event);
+} exits SEC(".maps.print");
+
+SEC("tracepoint/sched/sched_process_exit")
+int sched_process_exit(void *ctx)
+{
+        __u64 pid_tgid = bpf_get_current_pid_tgid();
+        __u32 pid = pid_tgid >> 32;
+        __u32 tid = (__u32)pid_tgid;
+        int exit_code;
+        struct task_struct *task;
+        struct event event = {};
+
+        if (target_pid && target_pid != pid)
+                return 0;
+
+        if (trace_by_process && pid != tid)
+                return 0;
+
+        task = (struct task_struct *)bpf_get_current_task();
+        exit_code = BPF_CORE_READ(task, exit_code);
+        if (trace_failed_only && exit_code == 0)
+                return 0;
+
+        event.start_time = BPF_CORE_READ(task, start_time);
+        event.exit_time = bpf_ktime_get_ns();
+        event.pid = pid;
+        event.tid = tid;
+        event.ppid = BPF_CORE_READ(task, real_parent, tgid);
+        event.sig = exit_code & 0xff;
+        event.exit_code = exit_code >> 8;
+        bpf_get_current_comm(event.comm, sizeof(event.comm));
+
+        struct event *ring_val;
+
+        ring_val = bpf_ringbuf_reserve(&exits, sizeof(struct event), 0);
+        if (!ring_val) {
+                return 0;
+        }
+
+        memcpy(ring_val, &event, sizeof(struct event));
+
+        /* submit event to ringbuf for printing */
+        bpf_ringbuf_submit(ring_val, 0);
+
+        return 0;
+}
+
+char LICENSE[] SEC("license") = "Dual BSD/GPL";

--- a/examples/exitsnoop/exitsnoop.c
+++ b/examples/exitsnoop/exitsnoop.c
@@ -6,9 +6,9 @@
 #include <bpf/bpf_core_read.h>
 #include "exitsnoop.h"
 
-const volatile pid_t target_pid = 0;
+//const volatile pid_t target_pid = 0;
+//const volatile bool trace_by_process = true;
 const volatile bool trace_failed_only = false;
-const volatile bool trace_by_process = true;
 
 struct {
         __uint(type, BPF_MAP_TYPE_RINGBUF);
@@ -26,11 +26,10 @@ int sched_process_exit(void *ctx)
         struct task_struct *task;
         struct event event = {};
 
-        if (target_pid && target_pid != pid)
-                return 0;
-
-        if (trace_by_process && pid != tid)
-                return 0;
+//        if (target_pid && target_pid != pid)
+//                return 0;
+//        if (trace_by_process && pid != tid)
+//                return 0;
 
         task = (struct task_struct *)bpf_get_current_task();
         exit_code = BPF_CORE_READ(task, exit_code);

--- a/examples/exitsnoop/exitsnoop.h
+++ b/examples/exitsnoop/exitsnoop.h
@@ -1,0 +1,18 @@
+/* SPDX-License-Identifier: (LGPL-2.1 OR BSD-2-Clause) */
+#ifndef __EXITSNOOP_H
+#define __EXITSNOOP_H
+
+#define TASK_COMM_LEN   16
+
+struct event {
+        __u64 start_time;
+        __u64 exit_time;
+        __u32 pid;
+        __u32 tid;
+        __u32 ppid;
+        __u32 sig;
+        int exit_code;
+        char comm[TASK_COMM_LEN];
+};
+
+#endif /* __EXITSNOOP_H */


### PR DESCRIPTION
This PR ports the [libbpf-tools version of exitsnoop](https://github.com/iovisor/bcc/blob/master/libbpf-tools/exitsnoop.bpf.c) to bee. 