### PR TITLE
Add oomkill example

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -51,6 +51,8 @@ activeconn: $(EXAMPLES_DIR)/activeconn
 tcpconnect: $(EXAMPLES_DIR)/tcpconnect
 .PHONY: exitsnoop
 tcpconnect: $(EXAMPLES_DIR)/exitsnoop
+.PHONY: oomkill
+tcpconnect: $(EXAMPLES_DIR)/oomkill
 
 
 $(EXAMPLES_DIR)/%:
@@ -58,7 +60,7 @@ $(EXAMPLES_DIR)/%:
 	$(OUTDIR)/bee-linux-amd64 push $(HUB)/$(REPO_NAME)/$*:$(VERSION)
 
 .PHONY: release-examples
-release-examples: activeconn tcpconnect exitsnoop
+release-examples: activeconn tcpconnect exitsnoop oomkill
 
 #----------------------------------------------------------------------------------
 # CLI

--- a/examples/oomkill/README.md
+++ b/examples/oomkill/README.md
@@ -1,0 +1,51 @@
+# Overview
+
+The oomkill example is heavily based on the [oomkill program in BCC's libbpf-tools](https://github.com/iovisor/bcc/blob/master/libbpf-tools/oomkill.bpf.c), which is itself based on the original [BCC oomkill](https://github.com/iovisor/bcc/blob/master/tools/oomkill.py), created by Brendan Gregg.
+
+The script traces the kernel out-of-memory killer, and prints details about which process was killed.
+
+The main difference between the original program and this one, is that here, we are using a new BPF data structure, called [BPF ring buffer](https://www.kernel.org/doc/html/latest/bpf/ringbuf.html), while the original one is using BPF perf buffer.
+
+Due to this decision, this version can be only used starting from Linux 5.8 kernel version, however this data structure solves multiple shortcomings of perfbuf, e.g. event ordering, and memory utilization, and using it instead of perfbuf is considered the current best practice.
+
+# Usage
+
+To see all the oomkills in your environment, you can run your image without filters:
+
+```console
+bee run ghcr.io/solo-io/bumblebee/oomkill:$(bee version)
+```
+
+You can also try out the filtering capability by referencing fields in your BPF map:
+
+```c
+struct data_t {
+        __u32 fpid;
+        __u32 tpid;
+        __u64 pages;
+        char fcomm[TASK_COMM_LEN];
+        char tcomm[TASK_COMM_LEN];
+};
+```
+
+The fields `tcomm`, and `tpid` identify the process that was oomkilled, while `fcomm` and `fpid` are details about the process that was triggering the oomkiller.
+
+For example, to filter for all the oomkills where the oomkilled process is `bash`, you can use: 
+
+```console
+bee run -f="exits,tcomm,bash" ghcr.io/solo-io/bumblebee/oomkill:$(bee version)
+```
+
+# Prometheus integration
+
+Visualizing and alerting on oomkills is crucial, and Bumblebee can help you with that.
+
+You can modify your `oomkills` structure to generate a `counter` from the oomkill events:
+
+```c
+struct {
+        __uint(type, BPF_MAP_TYPE_RINGBUF);
+        __uint(max_entries, 1 << 24);
+        __type(value, struct data_t);
+} oomkills SEC(".maps.counter");
+```

--- a/examples/oomkill/oomkill.c
+++ b/examples/oomkill/oomkill.c
@@ -1,0 +1,47 @@
+// SPDX-License-Identifier: GPL-2.0
+// Copyright (c) 2022 Jingxiang Zeng
+/* Adapted for `bee` from: https://github.com/iovisor/bcc/blob/master/libbpf-tools/oomkill.bpf.c */
+#include <vmlinux.h>
+#include <bpf/bpf_helpers.h>
+#include <bpf/bpf_core_read.h>
+#include <bpf/bpf_tracing.h>
+
+#define TASK_COMM_LEN 16
+
+struct data_t {
+        __u32 fpid;
+        __u32 tpid;
+        __u64 pages;
+        char fcomm[TASK_COMM_LEN];
+        char tcomm[TASK_COMM_LEN];
+};
+
+struct {
+        __uint(type, BPF_MAP_TYPE_RINGBUF);
+        __uint(max_entries, 1 << 24);
+        __type(value, struct data_t);
+} oomkills SEC(".maps.print");
+
+SEC("kprobe/oom_kill_process")
+int BPF_KPROBE(oom_kill_process, struct oom_control *oc, const char *message)
+{
+        struct data_t *e;
+
+        e = bpf_ringbuf_reserve(&oomkills, sizeof(struct data_t), 0);
+        if (!e) {
+                return 0;
+        }
+
+        e->tpid = bpf_get_current_pid_tgid();
+        bpf_get_current_comm(&e->fcomm, TASK_COMM_LEN);
+
+        e->fpid = bpf_get_current_pid_tgid() >> 32;
+        e->pages = BPF_CORE_READ(oc, totalpages);
+        bpf_probe_read_kernel(&e->tcomm, sizeof(e->tcomm), BPF_CORE_READ(oc, chosen, comm));
+
+        bpf_ringbuf_submit(e, 0);
+
+        return 0;
+}
+
+char LICENSE[] SEC("license") = "GPL";


### PR DESCRIPTION
This PR ports the [libbpf-tools version of oomkill](https://github.com/iovisor/bcc/blob/master/libbpf-tools/oomkill.bpf.c) to bee.