### PR TITLE
Add workflow for adding new issues to team boards

### DIFF
--- a/.github/workflows/issue_board.yaml
+++ b/.github/workflows/issue_board.yaml
@@ -1,0 +1,15 @@
+name: issue_board
+
+on:
+  issues:
+    types:
+      - opened
+jobs:
+  add-to-project:
+    name: Add Bumblebee to Gloo Mesh or Docs project board
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/add-to-project@main
+        with:
+          project-url: https://github.com/orgs/solo-io/projects/23
+          github-token: ${{ secrets.ORG_CROSS_REPO }}

--- a/.github/workflows/issue_board.yaml
+++ b/.github/workflows/issue_board.yaml
@@ -6,7 +6,7 @@ on:
       - opened
 jobs:
   add-to-project:
-    name: Add Bumblebee to Gloo Mesh or Docs project board
+    name: Add Bumblebee to Gloo Mesh.
     runs-on: ubuntu-latest
     steps:
       - uses: actions/add-to-project@main


### PR DESCRIPTION
I'm going through all our repos and adding a workflow that automatically adds new issues to the correct boards as part of: https://github.com/solo-io/gloo/issues/6305.