### PR TITLE
Expand the alias in the script on Debian/Ubuntu

### DIFF
--- a/install_cli.sh
+++ b/install_cli.sh
@@ -1,6 +1,7 @@
 #!/bin/sh
 
 set -eu
+shopt -s expand_aliases
 
 if [ -x "$(command -v python3)" ]; then
   alias any_python='python3'


### PR DESCRIPTION
man page says: `Aliases are not expanded when the shell is not interactive, unless the expand_aliases shell option is set using shopt (see the descriptioin of shopt under SHELL BUILTIN COMMANDS below).`

When using the install script on ubuntu I am getting this:

```bash
λ limactl shell ebpf2 bash -- ./install-bee.sh
++ command -v python3
+ '[' -x /usr/bin/python3 ']'
+ alias any_python=python3
+ '[' -z '' ']'
++ curl '-sHAccept: application/vnd.github.v3+json' -k https://api.github.com/repos/solo-io/bumblebee/releases
++ any_python -c 'import sys; from distutils.version import StrictVersion, LooseVersion; from json import loads as l; releases = l(sys.stdin.read()); releases = [release['\''tag_name'\''] for release in releases];  filtered_releases = list(filter(lambda release_string: len(release_string) > 0 and StrictVersion.version_re.match(release_string[1:]) != None, releases)); filtered_releases.sort(key=LooseVersion, reverse=True); print('\''\n'\''.join(filtered_releases))'
./install-bee.sh: line 18: any_python: command not found
```

`shopt -s expand_aliases` fixes this issue

Signed-off-by: Jirka Kremser <jiri.kremser@gmail.com>