### PR TITLE
use generic `bee` binary name

### DIFF
--- a/pkg/cli/internal/commands/package/Dockerfile
+++ b/pkg/cli/internal/commands/package/Dockerfile
@@ -7,4 +7,4 @@ COPY ./store /root/.bumblebee/store/
 
 ARG BPF_IMAGE
 ENV BPF_IMAGE=$BPF_IMAGE
-CMD ./bee-linux-amd64 run --no-tty ${BPF_IMAGE}
+CMD ./bee run --no-tty ${BPF_IMAGE}


### PR DESCRIPTION
Update the `bee package` command to work with the newly renamed `bee` binary (which was done in https://github.com/solo-io/bumblebee/pull/80)