### PR TITLE
Fix the target pid of oomkill example, expose metrics by default

### DIFF
--- a/examples/oomkill/README.md
+++ b/examples/oomkill/README.md
@@ -40,7 +40,7 @@ bee run -f="exits,tcomm,bash" ghcr.io/solo-io/bumblebee/oomkill:$(bee version)
 
 Visualizing and alerting on oomkills is crucial, and Bumblebee can help you with that.
 
-You can modify your `oomkills` structure to generate a `counter` from the oomkill events:
+Since we have the `.counter` prefix added to our `oomkills` map, exposing the oomkill events as a `counter` metric is enabled by default:
 
 ```c
 struct {
@@ -49,3 +49,5 @@ struct {
         __type(value, struct data_t);
 } oomkills SEC(".maps.counter");
 ```
+
+To disable this functionality, you can change the suffix to `.print`.

--- a/examples/oomkill/oomkill.c
+++ b/examples/oomkill/oomkill.c
@@ -20,7 +20,7 @@ struct {
         __uint(type, BPF_MAP_TYPE_RINGBUF);
         __uint(max_entries, 1 << 24);
         __type(value, struct data_t);
-} oomkills SEC(".maps.print");
+} oomkills SEC(".maps.counter");
 
 SEC("kprobe/oom_kill_process")
 int BPF_KPROBE(oom_kill_process, struct oom_control *oc, const char *message)
@@ -32,7 +32,7 @@ int BPF_KPROBE(oom_kill_process, struct oom_control *oc, const char *message)
                 return 0;
         }
 
-        e->tpid = bpf_get_current_pid_tgid();
+        e->tpid = BPF_CORE_READ(oc, chosen, tgid);
         bpf_get_current_comm(&e->fcomm, TASK_COMM_LEN);
 
         e->fpid = bpf_get_current_pid_tgid() >> 32;


### PR DESCRIPTION
This PR

-  fixes getting the target PID in the oomkill example by using `BPF_CORE_READ(oc, chosen, tgid)` instead of getting the current pid 
- enables exposing the events as metrics by default, so people can just pull/use the upstream image. The cardinality of the labels in this case is low, so I think this is a sensible default.

