### PR TITLE
UI displays an error message when there is a loading error

### DIFF
--- a/pkg/tui/tui.go
+++ b/pkg/tui/tui.go
@@ -155,6 +155,11 @@ func (a *App) Run(ctx context.Context, progLoader loader.Loader, loaderOpts *loa
 		logger.Info("calling Load()")
 		err := progLoader.Load(ctx, loaderOpts)
 		logger.Info("returned from Load()")
+		if err != nil {
+			logger.Error("error loading program")
+			a.renderLoadError(ctx, err)
+			go a.tviewApp.QueueUpdateDraw(func() {})
+		}
 		return err
 	})
 
@@ -272,6 +277,16 @@ func (a *App) renderHash(ctx context.Context, incoming loader.MapEntry) {
 		cell := tview.NewTableCell(eVal).SetExpansion(1)
 		table.SetCell(r, c, cell)
 	}
+}
+
+func (a *App) renderLoadError(ctx context.Context, err error) {
+	contextutils.LoggerFrom(ctx).Info("Rendering error")
+	tv := tview.NewTextView()
+	tv.SetText(fmt.Sprintf("%s", err))
+	tv.SetBorder(true)
+	tv.SetTitle("Error Loading Program")
+	tv.SetTitleColor(tcell.ColorRed)
+	a.flex.AddItem(tv, 0, 1, false)
 }
 
 func (a *App) NewRingBuf(name string, keys []string) {


### PR DESCRIPTION
When the ebpf verifier rejects the program that the user has written, we simply display an empty UI. It's not clear what has happened until the user exits the UI (it gets printed [here](https://github.com/solo-io/bumblebee/blob/main/bee/main.go#L14)). We can be more user friendly by displaying the verifier error to the user:

<img width="1257" alt="image" src="https://user-images.githubusercontent.com/5846846/207602335-bcf043ad-5e2e-4747-bc49-969198081c93.png">
