### PR TITLE
Delete stale metric labels from BPF maps

### DIFF
--- a/bee/main.go
+++ b/bee/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"fmt"
 	"log"
 
 	"github.com/solo-io/bumblebee/pkg/cli"
@@ -8,6 +9,7 @@ import (
 )
 
 func main() {
+	fmt.Println("this is my special bee")
 	// Use context with discarded logrus logger so we don't fill our logs unecessarily
 	ctx := context.Background()
 	if err := cli.Bee().ExecuteContext(ctx); err != nil {

--- a/bee/main.go
+++ b/bee/main.go
@@ -1,7 +1,6 @@
 package main
 
 import (
-	"fmt"
 	"log"
 
 	"github.com/solo-io/bumblebee/pkg/cli"
@@ -9,7 +8,6 @@ import (
 )
 
 func main() {
-	fmt.Println("this is my special bee")
 	// Use context with discarded logrus logger so we don't fill our logs unecessarily
 	ctx := context.Background()
 	if err := cli.Bee().ExecuteContext(ctx); err != nil {

--- a/examples/activeconn/activeconn.c
+++ b/examples/activeconn/activeconn.c
@@ -3,6 +3,7 @@
 #include "bpf/bpf_helpers.h"
 #include "bpf/bpf_core_read.h"
 #include "bpf/bpf_tracing.h"
+#include "unistd.h"
 
 char __license[] SEC("license") = "Dual MIT/GPL";
 
@@ -49,6 +50,7 @@ record(struct pt_regs *ctx, int ret, int op)
 	__u32 daddr;
 	u64 val;
 	u64 *valp;
+  __u32 myval;
 	struct dimensions_t key = {};
 
 	bpf_printk("exit: getting sk for tid: '%u', ret is: '%d'", tid, ret);
@@ -76,6 +78,11 @@ record(struct pt_regs *ctx, int ret, int op)
 	}
 	bpf_map_update_elem(&sockets_ext, &key, &val, 0);
 	bpf_map_delete_elem(&sockets, &tid);
+
+  myval = 1;
+	bpf_map_update_elem(&sockets_ext, &myval, &myval, 0);
+	sleep(5);
+	bpf_map_delete_elem(&sockets_ext, &myval)
 	return 0;
 }
 

--- a/examples/activeconn/activeconn.c
+++ b/examples/activeconn/activeconn.c
@@ -79,10 +79,6 @@ record(struct pt_regs *ctx, int ret, int op)
 	bpf_map_update_elem(&sockets_ext, &key, &val, 0);
 	bpf_map_delete_elem(&sockets, &tid);
 
-  myval = 1;
-	bpf_map_update_elem(&sockets_ext, &myval, &myval, 0);
-	sleep(5);
-	bpf_map_delete_elem(&sockets_ext, &myval)
 	return 0;
 }
 

--- a/examples/tcpconnect/tcpconnect.c
+++ b/examples/tcpconnect/tcpconnect.c
@@ -80,6 +80,7 @@ exit_tcp_connect(struct pt_regs *ctx, int ret)
 		val = 1;
 	}
 	else {
+	  bpf_map_delete_elem(&sockets, &tid);
 		bpf_printk("found existing value '%llu' for {saddr: %u, daddr: %u}", *valp, hash_key.saddr, hash_key.daddr);
 		val = *valp + 1;
 	}

--- a/pkg/loader/loader.go
+++ b/pkg/loader/loader.go
@@ -367,6 +367,7 @@ func (l *loader) startHashMap(
 		select {
 		case <-ticker.C:
 			mapIter := liveMap.Iterate()
+			labels := make([]map[string]string, 0)
 			for {
 				// Use generic key,value so we can decode ourselves
 				var (
@@ -398,12 +399,15 @@ func (l *loader) startHashMap(
 				}
 				stringLabels := stringify(decodedKey)
 				instrument.Set(ctx, int64(intVal), stringLabels)
+				labels = append(labels, stringLabels)
 				thisKvPair := KvPair{Key: stringLabels, Value: fmt.Sprint(intVal)}
 				watcher.SendEntry(MapEntry{
 					Name:  name,
 					Entry: thisKvPair,
 				})
 			}
+			// remove any old labels that weren't in this last iteration of the HashMap
+			instrument.Clean(labels)
 
 		case <-ctx.Done():
 			// fmt.Println("got done in hashmap loop, returning")
@@ -452,6 +456,8 @@ func (n *noop) Set(
 	labels map[string]string,
 ) {
 }
+
+func (n *noop) Clean(_ []map[string]string) {}
 
 func createDir(ctx context.Context, path string, perm os.FileMode) error {
 	file, err := os.Stat(path)

--- a/pkg/stats/stats.go
+++ b/pkg/stats/stats.go
@@ -105,7 +105,8 @@ func (m *metricsProvider) NewIncrementCounter(name string, labels []string) Incr
 
 	m.register(counter)
 	return &incrementCounter{
-		counter: counter,
+		counter:       counter,
+		currentLabels: map[string]map[string]string{},
 	}
 }
 
@@ -117,7 +118,8 @@ func (m *metricsProvider) NewGauge(name string, labels []string) SetInstrument {
 
 	m.register(gaugeVec)
 	return &gauge{
-		gauge: gaugeVec,
+		gauge:         gaugeVec,
+		currentLabels: map[string]map[string]string{},
 	}
 }
 


### PR DESCRIPTION
When an entry is removed from a map, we need to delete the associated metric. 