### PR TITLE
Adds histogram prometheus metrics

### DIFF
--- a/examples/nfsstats/nfsstats.c
+++ b/examples/nfsstats/nfsstats.c
@@ -1,0 +1,91 @@
+#include "vmlinux.h"
+#include "bpf/bpf_helpers.h"
+#include "bpf/bpf_core_read.h"
+#include "bpf/bpf_tracing.h"
+#include "solo_types.h"
+
+char __license[] SEC("license") = "Dual MIT/GPL";
+
+
+struct event {
+        char fname[255];
+        u64 le;
+};
+
+struct event_start {
+        u64 ts;
+        struct file *fp;
+};
+
+struct {
+        __uint(type, BPF_MAP_TYPE_HASH);
+        __uint(max_entries, 4096);
+        __type(key, u32);
+        __type(value, struct event_start);
+} start SEC(".maps");
+
+struct {
+        __uint(type, BPF_MAP_TYPE_RINGBUF);
+        __uint(max_entries, 1 << 24);
+        __type(value, struct event);
+} hist_file_read SEC(".maps");
+
+
+SEC("kprobe/nfs_file_read")
+int BPF_KPROBE(nfs_file_read, struct kiocb *iocb) {
+        bpf_printk("nfs_file_read happened");
+
+        struct event_start evt = {};
+
+        struct file *fp = BPF_CORE_READ(iocb, ki_filp);
+
+        u32 tgid = bpf_get_current_pid_tgid() >> 32;
+        u64 ts = bpf_ktime_get_ns();
+
+        evt.ts = ts;
+        evt.fp = fp;
+        bpf_map_update_elem(&start, &tgid, &evt, 0);
+
+        return 0;
+}
+
+SEC("kretprobe/nfs_file_read")
+int BPF_KRETPROBE(nfs_file_read_ret, ssize_t ret) {
+        bpf_printk("nfs_file_read returtned");
+
+        struct event evt = {};
+        struct file *fp;
+        struct dentry *dentry;
+        const __u8 *file_name;
+
+        u32 tgid = bpf_get_current_pid_tgid() >> 32;
+        struct event_start *rs;
+
+        rs = bpf_map_lookup_elem(&start, &tgid);
+        if (!rs)
+                return 0;
+
+        u64 ts = bpf_ktime_get_ns();
+        u64 duration = (ts - rs->ts) / 1000;
+
+        bpf_printk("nfs_file_read duration: %lld", duration);
+
+        evt.le = duration;
+
+        // decode filename
+        fp = rs->fp;
+        dentry = BPF_CORE_READ(fp, f_path.dentry);
+        file_name = BPF_CORE_READ(dentry, d_name.name);
+        bpf_probe_read_kernel_str(evt.fname, sizeof(evt.fname), file_name);
+        bpf_printk("nfs_file_read file_name: %s", evt.fname);
+
+
+        struct event *ring_val;
+        ring_val = bpf_ringbuf_reserve(&hist_file_read, sizeof(evt), 0);
+        if (!ring_val)
+                return 0;
+
+        memcpy(ring_val, &evt, sizeof(evt));
+        bpf_ringbuf_submit(ring_val, 0);
+
+}

--- a/examples/nfsstats/nfsstats.c
+++ b/examples/nfsstats/nfsstats.c
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: GPL-2.0
+
 #include "vmlinux.h"
 #include "bpf/bpf_helpers.h"
 #include "bpf/bpf_core_read.h"

--- a/examples/nfsstats/nfsstats.c
+++ b/examples/nfsstats/nfsstats.c
@@ -1,3 +1,4 @@
+// Based on: https://github.com/iovisor/bcc/blob/master/libbpf-tools/fsslower.bpf.c
 // SPDX-License-Identifier: GPL-2.0
 
 #include "vmlinux.h"

--- a/examples/nfsstats/nfsstats.c
+++ b/examples/nfsstats/nfsstats.c
@@ -4,8 +4,9 @@
 #include "bpf/bpf_tracing.h"
 #include "solo_types.h"
 
-char __license[] SEC("license") = "Dual MIT/GPL";
+// Example for tracing NFS file read duration using histogram metrics
 
+char __license[] SEC("license") = "Dual MIT/GPL";
 
 struct event {
         char fname[255];

--- a/pkg/cli/internal/commands/run/run.go
+++ b/pkg/cli/internal/commands/run/run.go
@@ -5,7 +5,6 @@ import (
 	"context"
 	"fmt"
 	"io"
-	"log"
 	"os"
 	"os/signal"
 	"strconv"
@@ -269,9 +268,7 @@ func buildContext(ctx context.Context, debug bool) (context.Context, error) {
 func parseWatchMapOptions(runOpts *runOptions) (map[string]loader.WatchedMapOptions, error) {
 	watchMapOptions := make(map[string]loader.WatchedMapOptions)
 
-	log.Printf("histBuckets: %v", runOpts.histBuckets)
 	for _, bucket := range runOpts.histBuckets {
-		log.Printf("bucket: %s", bucket)
 		mapName, bucketLimits, err := parseBucket(bucket)
 		if err != nil {
 			return nil, err

--- a/pkg/cli/internal/commands/run/run.go
+++ b/pkg/cli/internal/commands/run/run.go
@@ -290,6 +290,7 @@ func parseWatchMapOptions(runOpts *runOptions) (map[string]loader.WatchedMapOpti
 		}
 		w := watchMapOptions[mapName]
 		w.HistValueKey = valueKey
+		watchMapOptions[mapName] = w
 	}
 
 	return watchMapOptions, nil

--- a/pkg/cli/internal/commands/run/run.go
+++ b/pkg/cli/internal/commands/run/run.go
@@ -29,11 +29,15 @@ type runOptions struct {
 
 	debug    bool
 	filter   []string
+	buckets  []string
 	notty    bool
 	pinMaps  string
 	pinProgs string
 	promPort uint32
 }
+
+const bucketsDescription string = "Buckets to use for histogram maps. Format is \"map_name,<buckets_limits>\"" +
+	"where <buckets_limits> is a comma separated list of bucket limits. For example: \"events,[1,2,3,4,5]\""
 
 const filterDescription string = "Filter to apply to output from maps. Format is \"map_name,key_name,regex\" " +
 	"You can define a filter per map, if more than one defined, the last defined filter will take precedence"
@@ -43,6 +47,7 @@ var stopper chan os.Signal
 func addToFlags(flags *pflag.FlagSet, opts *runOptions) {
 	flags.BoolVarP(&opts.debug, "debug", "d", false, "Create a log file 'debug.log' that provides debug logs of loader and TUI execution")
 	flags.StringSliceVarP(&opts.filter, "filter", "f", []string{}, filterDescription)
+	flags.StringSliceVarP(&opts.buckets, "buckets", "b", []string{}, bucketsDescription)
 	flags.BoolVar(&opts.notty, "no-tty", false, "Set to true for running without a tty allocated, so no interaction will be expected or rich output will done")
 	flags.StringVar(&opts.pinMaps, "pin-maps", "", "Directory to pin maps to, left unpinned if empty")
 	flags.StringVar(&opts.pinProgs, "pin-progs", "", "Directory to pin progs to, left unpinned if empty")
@@ -72,6 +77,10 @@ $ bee run -f="events,comm,node" ghcr.io/solo-io/bumblebee/opensnoop:0.0.7
 
 To run with multiple filters, use the --filter (or -f) flag multiple times:
 $ bee run -f="events_hash,daddr,1.1.1.1" -f="events_ring,daddr,1.1.1.1" ghcr.io/solo-io/bumblebee/tcpconnect:0.0.7
+
+If your program has histogram output, you can supply the buckets using --buckets (or -b) flag:
+TODO(albertlockett) add a program w/ histogram buckets as example
+$ bee run -b="events,[1,2,3,4,5]" ghcr.io/solo-io/bumblebee/TODO:0.0.7
 `,
 		Args: cobra.ExactArgs(1), // Filename or image
 		RunE: func(cmd *cobra.Command, args []string) error {

--- a/pkg/cli/internal/commands/run/run.go
+++ b/pkg/cli/internal/commands/run/run.go
@@ -40,7 +40,7 @@ type runOptions struct {
 }
 
 const histBucketsDescription string = "Buckets to use for histogram maps. Format is \"map_name,<buckets_limits>\"" +
-	"where <buckets_limits> is a comma separated list of bucket limits. For example: \"events:[1,2,3,4,5]\""
+	"where <buckets_limits> is a comma separated list of bucket limits. For example: \"events,[1,2,3,4,5]\""
 
 const filterDescription string = "Filter to apply to output from maps. Format is \"map_name,key_name,regex\" " +
 	"You can define a filter per map, if more than one defined, the last defined filter will take precedence"

--- a/pkg/loader/loader.go
+++ b/pkg/loader/loader.go
@@ -66,9 +66,10 @@ func NewLoader(
 }
 
 const (
-	counterMapPrefix = "counter_"
-	gaugeMapPrefix   = "gauge_"
-	printMapPrefix   = "print_"
+	counterMapPrefix   = "counter_"
+	gaugeMapPrefix     = "gauge_"
+	histogramMapPrefix = "hist_"
+	printMapPrefix     = "print_"
 )
 
 func isPrintMap(spec *ebpf.MapSpec) bool {
@@ -83,8 +84,12 @@ func isCounterMap(spec *ebpf.MapSpec) bool {
 	return strings.HasPrefix(spec.Name, counterMapPrefix)
 }
 
+func isHistogramMap(spec *ebpf.MapSpec) bool {
+	return strings.HasPrefix(spec.Name, histogramMapPrefix)
+}
+
 func isTrackedMap(spec *ebpf.MapSpec) bool {
-	return isCounterMap(spec) || isGaugeMap(spec) || isPrintMap(spec)
+	return isCounterMap(spec) || isGaugeMap(spec) || isHistogramMap(spec) || isPrintMap(spec)
 }
 
 func (l *loader) Parse(ctx context.Context, progReader io.ReaderAt) (*ParsedELF, error) {
@@ -101,6 +106,7 @@ func (l *loader) Parse(ctx context.Context, progReader io.ReaderAt) (*ParsedELF,
 
 	watchedMaps := make(map[string]WatchedMap)
 	for name, mapSpec := range spec.Maps {
+		log.Println("mapSpec: ", mapSpec)
 		if !isTrackedMap(mapSpec) {
 			continue
 		}
@@ -256,14 +262,36 @@ func (l *loader) WatchMaps(
 		switch bpfMap.mapType {
 		case ebpf.RingBuf:
 			var increment stats.IncrementInstrument
+			var setIncrement stats.SetInstrument
+			var setKeyName string
+
 			if isCounterMap(bpfMap.mapSpec) {
 				increment = l.metricsProvider.NewIncrementCounter(name, bpfMap.Labels)
+			} else if isHistogramMap(bpfMap.mapSpec) {
+				setKeyName = "le"
+				histLabels := []string{}
+				for _, label := range bpfMap.Labels {
+					if label != setKeyName {
+						histLabels = append(histLabels, label)
+					}
+				}
+
+				setIncrement = l.metricsProvider.NewHistogram(
+					name,
+					histLabels,
+					// TODO: make this configurable
+					[]float64{0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10},
+				)
 			} else if isPrintMap(bpfMap.mapSpec) {
 				increment = &noop{}
 			}
 			eg.Go(func() error {
 				watcher.NewRingBuf(name, bpfMap.Labels)
-				return l.startRingBuf(ctx, bpfMap.valueStruct, maps[name], increment, name, watcher)
+				if setIncrement != nil {
+					return l.startRingBufSet(ctx, bpfMap.valueStruct, maps[name], setIncrement, name, setKeyName, watcher)
+				} else {
+					return l.startRingBufIncrement(ctx, bpfMap.valueStruct, maps[name], increment, name, watcher)
+				}
 			})
 		case ebpf.Array:
 			fallthrough
@@ -293,7 +321,7 @@ func (l *loader) WatchMaps(
 	return err
 }
 
-func (l *loader) startRingBuf(
+func (l *loader) startRingBufIncrement(
 	ctx context.Context,
 	valueStruct *btf.Struct,
 	liveMap *ebpf.Map,
@@ -347,6 +375,74 @@ func (l *loader) startRingBuf(
 			},
 		})
 	}
+}
+
+func (l *loader) startRingBufSet(
+	ctx context.Context,
+	valueStruct *btf.Struct,
+	liveMap *ebpf.Map,
+	instrument stats.SetInstrument,
+	name string,
+	valueKey string,
+	watcher MapWatcher,
+) error {
+	// Initialize decoder
+	d := l.decoderFactory()
+	logger := contextutils.LoggerFrom(ctx)
+
+	// Open a ringbuf reader from userspace RINGBUF map described in the
+	// eBPF C program.
+	rd, err := ringbuf.NewReader(liveMap)
+	if err != nil {
+		return fmt.Errorf("opening ringbuf reader: %v", err)
+	}
+	defer rd.Close()
+
+	// Close the reader when the process receives a signal, which will exit
+	// the read loop.
+	go func() {
+		<-ctx.Done()
+		logger.Info("in ringbuf set watcher, got done...")
+		if err := rd.Close(); err != nil {
+			logger.Infof("error while closing ringbuf '%s' reader: %s", name, err)
+		}
+		logger.Info("after reader.Close()")
+	}()
+
+	for {
+		record, err := rd.Read()
+		if err != nil {
+			if errors.Is(err, ringbuf.ErrClosed) {
+				logger.Info("ringbuf closed...")
+				return nil
+			}
+			logger.Infof("error while reading from ringbuf '%s' reader: %s", name, err)
+			continue
+		}
+		result, err := d.DecodeBtfBinary(ctx, valueStruct, record.RawSample)
+		if err != nil {
+			return err
+		}
+
+		intVal, ok := result[valueKey].(uint64)
+		if !ok {
+			return fmt.Errorf("value key '%s' is not a uint64", valueKey)
+		}
+
+		delete(result, valueKey)
+		stringLabels := stringify(result)
+
+		instrument.Set(ctx, int64(intVal), stringLabels)
+		watcher.SendEntry(MapEntry{
+			Name: name,
+			Entry: KvPair{
+				Key:   stringLabels,
+				Value: fmt.Sprint(intVal),
+			},
+		})
+
+	}
+
 }
 
 func (l *loader) startHashMap(

--- a/pkg/loader/loader.go
+++ b/pkg/loader/loader.go
@@ -439,10 +439,7 @@ func (l *loader) startRingBufSet(
 			return fmt.Errorf("value key '%s' is not a uint64", valueKey)
 		}
 
-		delete(result, valueKey)
 		stringLabels := stringify(result)
-
-		instrument.Set(ctx, int64(intVal), stringLabels)
 		watcher.SendEntry(MapEntry{
 			Name: name,
 			Entry: KvPair{
@@ -451,6 +448,8 @@ func (l *loader) startRingBufSet(
 			},
 		})
 
+		delete(result, valueKey)
+		instrument.Set(ctx, int64(intVal), stringify(result))
 	}
 
 }

--- a/pkg/loader/loader.go
+++ b/pkg/loader/loader.go
@@ -112,7 +112,6 @@ func (l *loader) Parse(ctx context.Context, progReader io.ReaderAt) (*ParsedELF,
 
 	watchedMaps := make(map[string]WatchedMap)
 	for name, mapSpec := range spec.Maps {
-		log.Println("mapSpec: ", mapSpec)
 		if !isTrackedMap(mapSpec) {
 			continue
 		}

--- a/pkg/stats/stats.go
+++ b/pkg/stats/stats.go
@@ -188,7 +188,7 @@ func (g *gauge) Set(
 	g.gauge.With(prometheus.Labels(decodedKey)).Set(float64(intVal))
 }
 
-type hisotgram struct {
+type histogram struct {
 	histogram *prometheus.HistogramVec
 }
 

--- a/pkg/stats/stats.go
+++ b/pkg/stats/stats.go
@@ -126,7 +126,7 @@ func (m *metricsProvider) NewHistogram(name string, labels []string, buckets []f
 	}, labels)
 
 	m.register(histogram)
-	return &hisotgram{
+	return &histogram{
 		histogram: histogram,
 	}
 

--- a/pkg/stats/stats.go
+++ b/pkg/stats/stats.go
@@ -192,7 +192,7 @@ type histogram struct {
 	histogram *prometheus.HistogramVec
 }
 
-func (h *hisotgram) Set(
+func (h *histogram) Set(
 	ctx context.Context,
 	intVal int64,
 	decodedKey map[string]string,

--- a/pkg/stats/stats.go
+++ b/pkg/stats/stats.go
@@ -119,15 +119,15 @@ func (m *metricsProvider) NewGauge(name string, labels []string) SetInstrument {
 }
 
 func (m *metricsProvider) NewHistogram(name string, labels []string, buckets []float64) SetInstrument {
-	histogram := prometheus.NewHistogramVec(prometheus.HistogramOpts{
+	h := prometheus.NewHistogramVec(prometheus.HistogramOpts{
 		Namespace: ebpfNamespace,
 		Name:      name,
 		Buckets:   buckets,
 	}, labels)
 
-	m.register(histogram)
+	m.register(h)
 	return &histogram{
-		histogram: histogram,
+		histogram: h,
 	}
 
 }


### PR DESCRIPTION
Adds histogram prometheus metrics. 

Users can specify histogram metrics using map type ringbuf by using the prefix `hist_`
```c
struct event {
        char fname[255];
        // by convention struct member 'le' will be the measurement 
        u64 le; 
};

struct {
        __uint(type, BPF_MAP_TYPE_RINGBUF);
        __uint(max_entries, 1 << 24);
        __type(value, struct event);
} hist_file_read SEC(".maps");
```

Histogram buckets, as well as the field containing the measurment value, can be provided as flags `-b/--hist-buckets` and `-k/--hist-value-key`

for example:
```
go run ./bee run --no-tty -b "hist_file_read,[1000,2000,5000,10000,20000]" myprog:latest
```

output:
```
curl -XGET -s localhost:9091/metrics | grep ebpf 
# HELP ebpf_solo_io_hist_file_read 
# TYPE ebpf_solo_io_hist_file_read histogram
ebpf_solo_io_hist_file_read_bucket{fname="test.txt",le="1000"} 7
ebpf_solo_io_hist_file_read_bucket{fname="test.txt",le="2000"} 8
ebpf_solo_io_hist_file_read_bucket{fname="test.txt",le="5000"} 14
ebpf_solo_io_hist_file_read_bucket{fname="test.txt",le="10000"} 16
ebpf_solo_io_hist_file_read_bucket{fname="test.txt",le="20000"} 19
ebpf_solo_io_hist_file_read_bucket{fname="test.txt",le="+Inf"} 20
ebpf_solo_io_hist_file_read_sum{fname="test.txt"} 107008
```

---
Also fixes bug where chars would get decoded as ints